### PR TITLE
HTMLファイルアップロードによるMarkdown変換機能を追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ Flask を使用したWebアプリケーション。
 URLを入力してMarkdownに変換するWeb UIとREST APIを提供。
 """
 from flask import Flask, render_template, request, jsonify
-from converter import convert_url, parse_selector, SITE_SELECTORS
+from converter import convert_url, convert_html, parse_selector, SITE_SELECTORS
 
 app = Flask(__name__)
 
@@ -83,6 +83,82 @@ def api_convert():
                 "markdown": result.markdown,
                 "title": result.title,
                 "url": result.url,
+                "selector_used": result.selector_used
+            }
+        })
+    else:
+        return jsonify({
+            "success": False,
+            "error": result.error
+        }), 400
+
+
+@app.route('/api/convert-file', methods=['POST'])
+def api_convert_file():
+    """
+    API: アップロードされたHTMLファイルをMarkdownに変換
+
+    Request: multipart/form-data
+        - file: HTMLファイル
+        - selector: カスタムセレクタ (optional)
+
+    Response (JSON):
+        {
+            "success": true,
+            "data": {
+                "markdown": "# Title\n...",
+                "title": "Article Title",
+                "selector_used": "default"
+            }
+        }
+    """
+    if 'file' not in request.files:
+        return jsonify({
+            "success": False,
+            "error": "ファイルが選択されていません"
+        }), 400
+
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({
+            "success": False,
+            "error": "ファイルが選択されていません"
+        }), 400
+
+    # 拡張子チェック
+    allowed_extensions = {'.html', '.htm', '.xhtml'}
+    filename = file.filename
+    ext = '.' + filename.rsplit('.', 1)[-1].lower() if '.' in filename else ''
+    if ext not in allowed_extensions:
+        return jsonify({
+            "success": False,
+            "error": "HTMLファイル（.html, .htm, .xhtml）のみ対応しています"
+        }), 400
+
+    # ファイル読み込み
+    try:
+        html_content = file.read().decode('utf-8')
+    except UnicodeDecodeError:
+        try:
+            file.seek(0)
+            html_content = file.read().decode('shift_jis')
+        except UnicodeDecodeError:
+            return jsonify({
+                "success": False,
+                "error": "ファイルのエンコーディングを判定できませんでした"
+            }), 400
+
+    selector = request.form.get('selector', '').strip() or None
+    custom_selector = parse_selector(selector)
+
+    result = convert_html(html_content, custom_selector, filename)
+
+    if result.success:
+        return jsonify({
+            "success": True,
+            "data": {
+                "markdown": result.markdown,
+                "title": result.title,
                 "selector_used": result.selector_used
             }
         })

--- a/converter.py
+++ b/converter.py
@@ -263,6 +263,53 @@ def convert_url(url: str, custom_selector: Optional[tuple] = None, timeout: int 
     )
 
 
+def convert_html(html: str, custom_selector: Optional[tuple] = None, filename: Optional[str] = None) -> ConversionResult:
+    """
+    HTML文字列からMarkdownに変換する関数
+
+    Args:
+        html: HTMLコンテンツ文字列
+        custom_selector: カスタムセレクタ (tag, attrs) のタプル
+        filename: アップロードされたファイル名
+
+    Returns:
+        ConversionResult: 変換結果
+    """
+    if not html or not html.strip():
+        return ConversionResult(
+            success=False,
+            error="HTMLコンテンツが空です"
+        )
+
+    # セレクタ決定
+    if custom_selector:
+        tag, attrs = custom_selector
+        selector_name = "custom"
+    else:
+        tag, attrs = SITE_SELECTORS["default"]["selector"]
+        selector_name = "default"
+
+    # 本文抽出
+    content_html, title = extract_content(html, tag, attrs)
+    if not content_html:
+        return ConversionResult(
+            success=False,
+            title=title,
+            error="本文を抽出できませんでした。セレクタを変更してみてください",
+            selector_used=selector_name
+        )
+
+    # Markdown変換
+    markdown = convert_to_markdown(content_html)
+
+    return ConversionResult(
+        success=True,
+        markdown=markdown,
+        title=title or filename,
+        selector_used=selector_name
+    )
+
+
 def parse_selector(selector_str: str) -> Optional[tuple]:
     """
     セレクタ文字列をパースして(tag, attrs)タプルに変換

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,31 +10,81 @@
                 <h5 class="mb-0"><i class="bi bi-arrow-repeat"></i> HTML to Markdown 変換</h5>
             </div>
             <div class="card-body">
-                <form id="convertForm">
-                    <div class="mb-3">
-                        <label for="urlInput" class="form-label">URL <span class="text-danger">*</span></label>
-                        <input type="url" class="form-control" id="urlInput"
-                               placeholder="https://example.com/article" required>
-                        <div class="form-text">変換したいWebページのURLを入力してください</div>
-                    </div>
-
-                    <div class="mb-3">
-                        <label for="selectorInput" class="form-label">
-                            セレクタ <span class="text-muted">(オプション)</span>
-                        </label>
-                        <input type="text" class="form-control" id="selectorInput"
-                               placeholder="例: div.content, main, article#post">
-                        <div class="form-text">
-                            本文の抽出に使用するCSSセレクタ。空欄の場合は自動判定します。
-                        </div>
-                    </div>
-
-                    <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-                        <button type="submit" class="btn btn-primary" id="convertBtn">
-                            <i class="bi bi-arrow-right-circle"></i> 変換
+                <!-- タブ切り替え -->
+                <ul class="nav nav-tabs mb-3" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="url-tab" data-bs-toggle="tab"
+                                data-bs-target="#url-pane" type="button" role="tab">
+                            <i class="bi bi-link-45deg"></i> URL入力
                         </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="file-tab" data-bs-toggle="tab"
+                                data-bs-target="#file-pane" type="button" role="tab">
+                            <i class="bi bi-file-earmark-code"></i> ファイルアップロード
+                        </button>
+                    </li>
+                </ul>
+
+                <div class="tab-content">
+                    <!-- URL入力タブ -->
+                    <div class="tab-pane fade show active" id="url-pane" role="tabpanel">
+                        <form id="convertForm">
+                            <div class="mb-3">
+                                <label for="urlInput" class="form-label">URL <span class="text-danger">*</span></label>
+                                <input type="url" class="form-control" id="urlInput"
+                                       placeholder="https://example.com/article" required>
+                                <div class="form-text">変換したいWebページのURLを入力してください</div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="selectorInput" class="form-label">
+                                    セレクタ <span class="text-muted">(オプション)</span>
+                                </label>
+                                <input type="text" class="form-control" id="selectorInput"
+                                       placeholder="例: div.content, main, article#post">
+                                <div class="form-text">
+                                    本文の抽出に使用するCSSセレクタ。空欄の場合は自動判定します。
+                                </div>
+                            </div>
+
+                            <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+                                <button type="submit" class="btn btn-primary" id="convertBtn">
+                                    <i class="bi bi-arrow-right-circle"></i> 変換
+                                </button>
+                            </div>
+                        </form>
                     </div>
-                </form>
+
+                    <!-- ファイルアップロードタブ -->
+                    <div class="tab-pane fade" id="file-pane" role="tabpanel">
+                        <form id="uploadForm">
+                            <div class="mb-3">
+                                <label for="fileInput" class="form-label">HTMLファイル <span class="text-danger">*</span></label>
+                                <input type="file" class="form-control" id="fileInput"
+                                       accept=".html,.htm,.xhtml" required>
+                                <div class="form-text">変換したいHTMLファイルを選択してください（.html, .htm, .xhtml）</div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="fileSelectorInput" class="form-label">
+                                    セレクタ <span class="text-muted">(オプション)</span>
+                                </label>
+                                <input type="text" class="form-control" id="fileSelectorInput"
+                                       placeholder="例: div.content, main, article#post">
+                                <div class="form-text">
+                                    本文の抽出に使用するCSSセレクタ。空欄の場合は自動判定します。
+                                </div>
+                            </div>
+
+                            <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+                                <button type="submit" class="btn btn-primary" id="uploadBtn">
+                                    <i class="bi bi-upload"></i> アップロードして変換
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -109,8 +159,29 @@ document.addEventListener('DOMContentLoaded', function() {
     const copyBtn = document.getElementById('copyBtn');
     const downloadBtn = document.getElementById('downloadBtn');
 
+    const uploadForm = document.getElementById('uploadForm');
+    const fileInput = document.getElementById('fileInput');
+    const fileSelectorInput = document.getElementById('fileSelectorInput');
+    const uploadBtn = document.getElementById('uploadBtn');
+
     let currentMarkdown = '';
     let currentTitle = '';
+
+    // 結果表示の共通処理
+    function showResult(data) {
+        currentMarkdown = data.data.markdown;
+        currentTitle = data.data.title || 'untitled';
+        resultTitle.textContent = data.data.title || '変換結果';
+        markdownOutput.textContent = currentMarkdown;
+        selectorUsed.textContent = data.data.selector_used;
+        resultArea.style.display = 'block';
+        resultArea.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    function showError(message) {
+        document.getElementById('errorMessage').textContent = message;
+        errorArea.style.display = 'block';
+    }
 
     form.addEventListener('submit', async function(e) {
         e.preventDefault();
@@ -134,27 +205,49 @@ document.addEventListener('DOMContentLoaded', function() {
             const data = await response.json();
 
             if (data.success) {
-                currentMarkdown = data.data.markdown;
-                currentTitle = data.data.title || 'untitled';
-
-                resultTitle.textContent = data.data.title || '変換結果';
-                markdownOutput.textContent = currentMarkdown;
-                selectorUsed.textContent = data.data.selector_used;
-                resultArea.style.display = 'block';
-
-                // 結果エリアまでスクロール
-                resultArea.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                showResult(data);
             } else {
-                document.getElementById('errorMessage').textContent = data.error;
-                errorArea.style.display = 'block';
+                showError(data.error);
             }
         } catch (error) {
-            document.getElementById('errorMessage').textContent =
-                '通信エラーが発生しました。ネットワーク接続を確認してください。';
-            errorArea.style.display = 'block';
+            showError('通信エラーが発生しました。ネットワーク接続を確認してください。');
         } finally {
             convertBtn.disabled = false;
             convertBtn.innerHTML = '<i class="bi bi-arrow-right-circle"></i> 変換';
+        }
+    });
+
+    // ファイルアップロード処理
+    uploadForm.addEventListener('submit', async function(e) {
+        e.preventDefault();
+
+        uploadBtn.disabled = true;
+        uploadBtn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> 変換中...';
+        resultArea.style.display = 'none';
+        errorArea.style.display = 'none';
+
+        try {
+            const formData = new FormData();
+            formData.append('file', fileInput.files[0]);
+            formData.append('selector', fileSelectorInput.value);
+
+            const response = await fetch('/api/convert-file', {
+                method: 'POST',
+                body: formData
+            });
+
+            const data = await response.json();
+
+            if (data.success) {
+                showResult(data);
+            } else {
+                showError(data.error);
+            }
+        } catch (error) {
+            showError('通信エラーが発生しました。ネットワーク接続を確認してください。');
+        } finally {
+            uploadBtn.disabled = false;
+            uploadBtn.innerHTML = '<i class="bi bi-upload"></i> アップロードして変換';
         }
     });
 


### PR DESCRIPTION
## Summary
- ローカルHTMLファイル(.html/.htm/.xhtml)のアップロードによるMarkdown変換機能を追加
- Web UIにタブ切り替え（URL入力 / ファイルアップロード）を実装
- `converter.py`に`convert_html()`関数、`app.py`に`POST /api/convert-file`エンドポイントを追加
- UTF-8 / Shift_JIS のエンコーディング自動判定に対応

## Test plan
- [ ] URL入力タブで従来通りURL変換が動作すること
- [ ] ファイルアップロードタブでHTMLファイルの変換が動作すること
- [ ] 非HTMLファイルをアップロードした場合にエラーが表示されること
- [ ] セレクタ指定ありの場合に正しく本文が抽出されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)